### PR TITLE
Add support for A5 PDF output

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Requirements:
 
  * Python3. Install natsort module: `pip install natsort`.
  * [Pandoc](https://pandoc.org/installing.html). Install [version 2.9](https://github.com/jgm/pandoc/releases/tag/2.9.2.1)
- * `pandoc-fignos` and `pandoc-tablenos`. Run `pip install pandoc-fignos pandoc-tablenos`.
- * `pandoc-crossref`. This one requires manual installation. I just downloaded the binary from [here](https://github.com/lierdakil/pandoc-crossref/releases/tag/v0.3.6.4) and copied it to the same place where `pandoc-fignos` is.
+ * `pandoc-fignos` and `pandoc-tablenos`. Run `pip install pandoc-fignos==2.3.1 pandoc-tablenos==2.3.0`.
+ * `pandoc-crossref`. This one requires manual installation. I just downloaded the binary from [here](https://github.com/lierdakil/pandoc-crossref/releases/tag/v0.3.6.4) and copied it to the same place where `pandoc-fignos` is. The other option (at least on Windows) is to put `pandoc-crossref.exe` in the repo root along with `pandoc.exe`.
  * [MiKTeX](https://miktex.org/download). Check `Yes` for automatic package installation.
 
 Run:

--- a/export_book.py
+++ b/export_book.py
@@ -10,6 +10,7 @@ import re
 parser = argparse.ArgumentParser(description='Export book')
 parser.add_argument("-ch", type=int, help="Chapter to export", default="99")
 parser.add_argument("-pdf", help="Export for PDF print", action="store_true", default=False)
+parser.add_argument("-pdfa5", help="Export for PDF print in A5 dimensions", action="store_true", default=False)
 parser.add_argument("-paperback", help="Export for paperback print", action="store_true", default=False)
 parser.add_argument("-kindle", help="Export the kindle version", action="store_true", default=False)
 parser.add_argument("-v", help="verbose", action="store_true", default=False)
@@ -72,6 +73,16 @@ elif args.pdf:
   pandoc_cmd = pandoc_cmd + "-V geometry:top=2cm "
   pandoc_cmd = pandoc_cmd + "-V geometry:bottom=2cm "
   pandoc_cmd = pandoc_cmd + "-V fontsize:8pt "
+elif args.pdfa5:
+  pandoc_cmd = pandoc_cmd + "--include-before-body cover.tex "
+  pandoc_cmd = pandoc_cmd + "-V classoption=twoside "
+  pandoc_cmd = pandoc_cmd + "-V geometry:paperwidth=148mm "
+  pandoc_cmd = pandoc_cmd + "-V geometry:paperheight=210mm "  
+  pandoc_cmd = pandoc_cmd + "-V geometry:left=1.5cm "
+  pandoc_cmd = pandoc_cmd + "-V geometry:right=1.5cm "
+  pandoc_cmd = pandoc_cmd + "-V geometry:top=1.5cm "
+  pandoc_cmd = pandoc_cmd + "-V geometry:bottom=1.5cm "
+  pandoc_cmd = pandoc_cmd + "-V fontsize=10pt "
 
 pandoc_cmd = pandoc_cmd + "--filter pandoc-fignos --filter pandoc-tablenos --filter pandoc-crossref --natbib -o book.tex metadata.txt "
 


### PR DESCRIPTION
Tested on Windows, `export_book.py` with `-pdfa5` specified outputs an A5 paper sized PDF file. Note that I made the font slightly bigger (though it doesn't seem to have much of an effect).

@dendibakh thanks for the great book!

Related #38.