### PR TITLE
Fix subtle bug for SIMD finding new line in chapter 10-4

### DIFF
--- a/chapters/10-Optimizing-Branch-Prediction/10-4 Multiple Compares Single Branch.md
+++ b/chapters/10-Optimizing-Branch-Prediction/10-4 Multiple Compares Single Branch.md
@@ -47,7 +47,7 @@ uint32_t longestLine(const std::string &str) {
       lineBeginPos += curLen + 1;
       // Is this line the longest?
       maxLen = std::max(curLen, maxLen);
-      // Shift the mask to check if we have more '\n'
+      // Shift the mask to check if we have more '\n'. Notice shift by 8 bits on uint8_t is UB.
       mask >>= eolPos + 1;
     }
   }


### PR DESCRIPTION
**Brief**:

+ the code might be incorrect when there are more than 1 newliner `\n` in 8-byte chunks. Since we are shifting `mask` after we find a newliner, `eolPos` is a relative position (relative to mask) in this chunk. But `uint32_t curLen = (pos - lineBeginPos) + eolPos;` is an absolute position. 

+ understood this is just demo purpose. But shift 8 bytes is UB.

I had a test version on this working here (https://github.com/dendibakh/perf-ninja/commit/cf70700506ed315cb0c87244f04f3f003a807697) 
